### PR TITLE
add meta tags for Twitter app cards fixes #10

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,13 @@
   <meta property="og:description" content="A free and open source Jabber/XMPP client for Android. Easy to use, reliable, battery friendly. With built-in support for images, group chats and e2e encryption.">
   <meta name="description" content="A free and open source Jabber/XMPP client for Android. Easy to use, reliable, battery friendly. With built-in support for images, group chats and e2e encryption.">
 
+  <meta name="twitter:card" content="app">
+  <meta name="twitter:site" content="@iNPUTmice">
+  <meta name="twitter:description" content="A free and open source Jabber/XMPP client for Android. Easy to use, reliable, battery friendly. With built-in support for images, group chats and e2e encryption."> 
+  <meta name="twitter:app:country" content="US">
+  <meta name="twitter:app:name:googleplay" content="Conversations"> 
+  <meta name="twitter:app:id:googleplay" content="eu.siacs.conversations">
+
   <title>Conversations: the very last word in instant messaging</title>
   <link href="css/bootstrap.min.css" rel="stylesheet">
   <link href="css/custom.css" rel="stylesheet">


### PR DESCRIPTION
one more requires the deep link url for launching the app to the main screen if already installed...
  Eg: `<meta name="twitter:app:url:googleplay" content="https://home.conversations.im">`

You may need to test it using https://cards-dev.twitter.com/validator